### PR TITLE
feat: add Railway deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@
 # Generate one with: openssl rand -hex 32
 GYD_JWT_SECRET=replace-this-with-a-random-32-plus-char-secret
 
+# Admin account credentials — used by entrypoint.sh to run 'gatheryourdeals init'
+# non-interactively on container startup. Required when running via Docker.
+GYD_ADMIN_USERNAME=admin
+GYD_ADMIN_PASSWORD=replace-this-with-a-strong-password
+
 # Database driver. Overrides database.driver in config.yaml.
 # Valid values: sqlite (default), postgres
 # GYD_DATABASE_DRIVER=postgres
@@ -16,8 +21,19 @@ GYD_JWT_SECRET=replace-this-with-a-random-32-plus-char-secret
 #   postgres://user:password@host:5432/dbname?sslmode=require
 # Accepts key-value DSN format:
 #   host=myserver.postgres.database.azure.com port=5432 dbname=mydb user=mylogin password=secret sslmode=require
-# Railway auto-injects DATABASE_URL when a PostgreSQL add-on is provisioned.
+# Railway and Azure auto-inject DATABASE_URL when a PostgreSQL add-on is provisioned.
 # DATABASE_URL=
+
+# ── Server ────────────────────────────────────────────────────────────────────
+# PORT is the standard env var injected by Railway and Azure Container Apps.
+# Overrides server.port in config.yaml (default: 8080).
+# PORT=8080
+
+# ── Auth token expiry ─────────────────────────────────────────────────────────
+# Override auth.access_token_exp and auth.refresh_token_exp in config.yaml.
+# Uses Go duration syntax: 15m, 1h, 24h, 168h, etc.
+# GYD_ACCESS_TOKEN_EXP=1h
+# GYD_REFRESH_TOKEN_EXP=168h
 
 # ── OpenTelemetry / Honeycomb (optional) ─────────────────────────────────────
 # Leave OTEL_EXPORTER_OTLP_ENDPOINT blank to disable all OTel export.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/gatheryourdeals /usr/local/bin/gatheryourdeals
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-# Data directory for the database file
+# Data directory for the database file (SQLite local dev only)
 RUN mkdir -p /data
 WORKDIR /data
 
 EXPOSE 8080
 
-ENTRYPOINT ["gatheryourdeals", "--config", "/data/config.yaml"]
-CMD ["serve"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ Logs are written to stdout (visible via `docker compose logs`) and to rotating f
 > If you must use a secret that contains a dollar sign, escape each one
 > by doubling it (e.g. `$$`).
 
+## Configuration
+
+Configuration is loaded in this order — later values override earlier ones:
+
+1. Built-in defaults
+2. `config.yaml` (optional — if the file is absent, defaults apply)
+3. Environment variables (always win)
+
+This means the service runs without any config file on Railway, Azure, or any container platform — everything can be driven by env vars alone. `config.yaml` remains useful for local development.
+
+### Environment variables
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GYD_JWT_SECRET` | — | **Required.** JWT signing secret, minimum 32 characters. Generate with `openssl rand -hex 32`. |
+| `PORT` | `8080` | HTTP listen port. Injected automatically by Railway and Azure Container Apps. |
+| `GYD_DATABASE_DRIVER` | `sqlite` | Database backend. Set to `postgres` for cloud deployment. |
+| `DATABASE_URL` | — | PostgreSQL connection string. Injected automatically by Railway when a PostgreSQL add-on is provisioned. |
+| `GYD_ACCESS_TOKEN_EXP` | `1h` | Access token lifetime. Go duration syntax: `15m`, `1h`, `24h`. |
+| `GYD_REFRESH_TOKEN_EXP` | `168h` | Refresh token lifetime. Go duration syntax: `24h`, `168h`, `720h`. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry export endpoint (e.g. `https://api.honeycomb.io`). Leave blank to disable tracing. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | OTel headers, e.g. `x-honeycomb-team=<key>`. |
+| `OTEL_SERVICE_NAME` | `gatheryourdeals` | Service name shown in traces. |
+| `OTEL_RESOURCE_ATTRIBUTES` | — | Comma-separated span attributes, e.g. `service.environment=production,db.type=postgres`. |
+
+See `.env.example` for a full annotated template.
+
 ## Logging
 
 All logs (Gin request logs and application logs) go to both stdout and a rotating log file. Log files are named with their creation timestamp, e.g. `gatheryourdeals-2025-04-05-14-30-00.log`. Only the two most recent files are kept.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Run init non-interactively using credentials from env vars.
+# On first deploy this creates the admin account.
+# On subsequent deploys initCmd detects the existing admin and exits cleanly.
+if [ -n "$GYD_ADMIN_USERNAME" ] && [ -n "$GYD_ADMIN_PASSWORD" ]; then
+    printf '%s\n%s\n%s\n' \
+        "$GYD_ADMIN_USERNAME" \
+        "$GYD_ADMIN_PASSWORD" \
+        "$GYD_ADMIN_PASSWORD" \
+        | gatheryourdeals init
+else
+    echo "ERROR: GYD_ADMIN_USERNAME and GYD_ADMIN_PASSWORD must be set" >&2
+    exit 1
+fi
+
+# Replace shell with the server process so SIGTERM reaches Go directly.
+exec gatheryourdeals serve

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,21 +51,33 @@ type AuthConfig struct {
 }
 
 // Load reads the config from a YAML file at the given path.
-// After parsing, GYD_DATABASE_DRIVER env var overrides database.driver if set.
+// If the file does not exist, built-in defaults and environment variables are used.
+// After parsing, environment variables override any file-based values.
 func Load(path string) (*Config, error) {
+	var cfg Config
+
 	data, err := os.ReadFile(path)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
-
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse config file: %w", err)
+	if err == nil {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse config file: %w", err)
+		}
 	}
 
-	// Allow GYD_DATABASE_DRIVER to override the config file driver value.
+	// Environment variable overrides.
 	if d := os.Getenv("GYD_DATABASE_DRIVER"); d != "" {
 		cfg.Database.Driver = d
+	}
+	if p := os.Getenv("PORT"); p != "" {
+		cfg.Server.Port = p
+	}
+	if v := os.Getenv("GYD_ACCESS_TOKEN_EXP"); v != "" {
+		cfg.Auth.AccessTokenExp = v
+	}
+	if v := os.Getenv("GYD_REFRESH_TOKEN_EXP"); v != "" {
+		cfg.Auth.RefreshTokenExp = v
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+builder = "dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary

- Added `railway.toml` with Dockerfile builder, `/health` healthcheck, and restart-on-failure policy
- Updated `Dockerfile` to use `entrypoint.sh` instead of hardcoded `--config` flag
- Added `entrypoint.sh` to run `init` (migrations + admin account) then `serve`
- Updated `internal/config/config.go` to make config file optional — env vars alone are sufficient
- Added `PORT`, `GYD_ACCESS_TOKEN_EXP`, `GYD_REFRESH_TOKEN_EXP` env var overrides to config
- Updated `.env.example` and `README.md` with new env vars and Railway deployment docs

## Why

Railway builds from `main`. Without these files on `main`, the Dockerfile references a missing `entrypoint.sh` and Railway cannot deploy correctly. This PR brings `main` up to date so Railway auto-deploys work end-to-end.

## Test plan

- [ ] PR merges cleanly (no conflicts)
- [ ] Railway redeploys from `main` after merge
- [ ] `/health` returns 200
- [ ] Admin login works with `GYD_ADMIN_USERNAME` / `GYD_ADMIN_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)