### PR TITLE
fix: chmod results dir in run_all.sh for Locust container write access

### DIFF
--- a/load_testing/run_all.sh
+++ b/load_testing/run_all.sh
@@ -151,6 +151,9 @@ log "Guardrail passed."
 RUN_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RUN_DIR="${GYD_RESULTS_DIR:-results}/${RUN_TIMESTAMP}"
 mkdir -p "$RUN_DIR"
+# Allow the Locust container (runs as uid 1000) to write results even when
+# the directory was created by a different host user (e.g. CI runner uid 1001).
+chmod a+rwx "$RUN_DIR"
 log "Results directory: ${RUN_DIR}"
 
 # ── Group definitions: (locust_file, group_label) ────────────────────────────


### PR DESCRIPTION
## Summary

`run_all.sh` creates the results subdirectory but it also needs `chmod a+rwx` — same uid mismatch as the previous `run_group.sh` fix.

When `group=all` in CI, `run_all.sh` is the entry point (not `run_group.sh`), so the previous fix didn't help.

## Root cause

Run 23592434960 — all 4 groups still failed with:
```
PermissionError: [Errno 13] Permission denied: 'results/20260326_114250/group1_cpu_moderate_stats.csv'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)