### PR TITLE
fix: raise StopUser on login failure instead of quitting entire run

### DIFF
--- a/load_testing/locust/common.py
+++ b/load_testing/locust/common.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 
 import requests
 from locust import HttpUser, events
+from locust.exception import StopUser
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +87,7 @@ def login(base_url, username, password):
     resp = requests.post(
         f"{base_url}/api/v1/auth/login",
         json={"username": username, "password": password},
-        timeout=10,
+        timeout=30,
     )
     if resp.status_code != 200:
         raise RuntimeError(
@@ -105,16 +106,15 @@ def login(base_url, username, password):
 
 def safe_login(environment, base_url, username, password):
     """
-    Call login() and abort the entire test run on failure.
-    Locust silently swallows on_start() exceptions, so login failures would
-    produce 0 requests with no visible error. This surfaces them immediately.
+    Call login() and stop only the failing user on failure (raises StopUser).
+    This surfaces the error without aborting the entire test run — other users
+    that successfully log in continue running tasks normally.
     """
     try:
         return login(base_url, username, password)
     except Exception as exc:
-        print(f"\n[FATAL] Login failed for '{username}': {exc}", file=sys.stderr)
-        environment.runner.quit()
-        raise
+        print(f"\n[WARN] Login failed for '{username}', stopping this user: {exc}", file=sys.stderr)
+        raise StopUser() from exc
 
 
 class BaseGYDUser(HttpUser):


### PR DESCRIPTION
## Summary

- `safe_login()` was calling `environment.runner.quit()` on any login error, aborting the entire test run
- On Railway where bcrypt login takes >10s under load, all `on_start()` logins would time out, causing **0 requests for groups 2–4**
- Fix 1: Raise `StopUser` instead — drops only the failing user, test continues for others
- Fix 2: Increase `login()` timeout from 10s → 30s to accommodate Railway's slower response times

## Root cause

Week1 local run: login avg 785ms. CI Railway run: login avg **16s** under group1's bcrypt load.
All group2–4 users' `on_start()` timed out in 10s → `runner.quit()` → 0 requests, 36s early exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)