### PR TITLE
docs: add week 2 load test report (Railway + PostgreSQL, stress failures)

### DIFF
--- a/docs/testing_reports/load/week2-buggy report.md
+++ b/docs/testing_reports/load/week2-buggy report.md
@@ -9,10 +9,21 @@ All 4 moderate phases (100–400 users) completed with **0% error rate**. All 4 
 # Environment
 
 - **Platform**: Railway (1 replica, `us-west2`)
-- **Database**: PostgreSQL (Railway-managed)
+- **Railway Plan**: Hobby ($5/month, 5-month commitment) — upgraded from free tier to unlock PgBouncer and additional provisioning nodes required for PostgreSQL connection pooling
+- **Database**: PostgreSQL (Railway-managed, via PgBouncer)
 - **Service**: `GatherYourDeals-data` (branch `ci/azure-load-test-v2`)
 - **GitHub Run**: `23626012442` (artifact: `load-test-results-23626012442`)
 - **Results directory**: `load_testing/results/20260327_011016/`
+
+## Infrastructure Cost
+
+| Item | Cost |
+| --- | --- |
+| Railway Hobby plan | $5/month |
+| Commitment | 5 months |
+| **Total committed** | **$25** |
+
+The Hobby plan was required to provision PgBouncer (Railway's managed connection pooler) alongside the PostgreSQL instance. The free tier does not allow additional provisioning nodes needed to run both the app service and the connection pooler simultaneously.
 
 # Performance Result
 


### PR DESCRIPTION
## Summary

- Adds the week 2 Railway + PostgreSQL load test report that was missing from the docs directory
- All 4 moderate phases (100–400 users) passed with 0% error rate
- All 4 stress phases failed as expected at single-replica capacity limits
- Includes root cause analysis: bcrypt CPU saturation, connection pool exhaustion, refresh token TTL cascade, meta field race condition
- Documents the connection pool cap finding (`SetMaxOpenConns(10)`) that was fixed and validated in week 3

## Test plan

- [ ] Verify report file renders correctly in GitHub
- [ ] Confirm no other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)