### PR TITLE
docs: add pre-merge branch sync check rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,16 @@ These rules govern how much agents can act independently versus when they must s
 
 # IMPORTANT FOR GIT
 
-PELASE ALWAYS CHECK IF BRANCH IS UPDATE WITH TARGET IF YOU HAVE PR!!!
+PLEASE ALWAYS CHECK IF BRANCH IS UP TO DATE WITH TARGET IF YOU HAVE A PR!!!
+
+## Pre-merge branch sync check
+
+Before merging any PR (to `develop` or `main`), run:
+```bash
+git fetch origin
+git log HEAD..origin/<base-branch> --oneline
+```
+If any commits are listed, the branch is behind — **rebase first, then merge**. Do not merge a stale branch.
 
 ## During Execution
 Run uninterrupted. Do not pause to ask questions mid-task unless blocked.


### PR DESCRIPTION
## Summary

- Formalizes the existing "check branch is up to date" reminder into an explicit rule
- Adds the exact `git fetch` + `git log HEAD..origin/<base>` commands to run before any merge
- Fixes the typo in the header ("PELASE" → "PLEASE")

🤖 Generated with [Claude Code](https://claude.com/claude-code)