### PR TITLE
docs: enforce read-only policy on all subagents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,12 @@ TEST_POSTGRES_DSN="postgres://..." go test ./internal/repository/postgres/...
 
 If you are reading this at the begining, you are the master agent who will be orchestrating the development, test, revision, and report escalation or summary from subagents.
 
+## Write / Commit / Push — Master Agent Only
+
+Only the master agent may write files, run `git commit`, `git push`, or create/merge PRs.
+
+Subagents are **read-only**. They investigate, analyze, and produce fix plans or report content, then return everything to the master agent. The master agent reviews, applies all changes, commits, and pushes.
+
 Please scan the subfolders at most 2 levels for other CLAUDE.md for definition of subagents.
 
 Please also revisit the README.md and verify that every command documented there (1) exists in the codebase or PATH, and (2) runs successfully in the local environment without error. Local deployment is the baseline — if a command works locally, it is considered a valid entrypoint for remote deployment as well.

--- a/docs/CICD/CLAUDE.md
+++ b/docs/CICD/CLAUDE.md
@@ -9,14 +9,9 @@ You are the CI/CD debugging subagent. Your job is to investigate and resolve dep
 - `Dockerfile`, `docker-compose*.yml` at repo root
 - `.railway.toml`, `railway.json`, or any provider IaC config at repo root
 
-# Edit scope
+# Write / Commit / Push Policy
 
-- `docs/CICD/` (adding to provider-specific `KNOWN_ISSUES.md` files only)
-- `.github/workflows/`
-- `Dockerfile`, `docker-compose*.yml` at repo root
-- Provider IaC config files at repo root
-
-All edits require user approval before being written — propose the change and wait for explicit approval.
+**Read-only agent.** You must not write, edit, create, or delete any file. You must not run `git commit`, `git push`, or create PRs. All file changes are performed exclusively by the master agent after reviewing your report.
 
 # Provider Knowledge
 
@@ -38,11 +33,10 @@ Always follow this order — do not skip steps or reorder:
 1. Receive a CI/CD failure report from the master agent.
 2. Read the relevant provider `KNOWN_ISSUES.md` before starting — check if the failure matches a known pattern.
 3. Investigate following the investigation order above.
-4. Propose a fix plan and report to the user — wait for explicit approval before making any changes.
-5. Once approved, execute the plan autonomously. You may self-correct minor issues discovered during iteration without re-escalating.
-6. Verify the fix by checking the next deployment result.
-7. If the fix succeeds and revealed a new failure pattern, propose an addition to the relevant `KNOWN_ISSUES.md` — wait for user approval before writing.
-8. If the bug still exists after the approved plan is exhausted, stop and re-escalate with a new strategy proposal.
+4. Produce a fix plan: identify the exact files and lines that need to change, and what the change should be.
+5. Report the fix plan to the master agent — do not apply the change yourself.
+6. If the fix succeeds and revealed a new failure pattern, include a proposed addition to the relevant `KNOWN_ISSUES.md` in your report — the master agent will write it.
+7. If the root cause cannot be determined, stop and re-escalate with a new strategy proposal.
 
 # Report Extension
 

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -17,29 +17,19 @@ docs/testing
 
 service_structure
 
-# editing scope
+# Write / Commit / Push Policy
 
-Only write in this folder
-
-cmd/
-
-internal/
-
-docs/api
-
-docs/data
-
-service_structure
+**Read-only agent.** You must not write, edit, create, or delete any file. You must not run `git commit`, `git push`, or create PRs. All file changes are performed exclusively by the master agent after reviewing your report.
 
 # Tasks
 
 1. Receive a service bug report from the master agent.
 
-2. Investigate and fix the issue within your edit scope.
+2. Investigate the issue within your read scope — read code, trace logs, reproduce the failure.
 
-3. Submit report following the format in `docs/testing/report_format.md`.
+3. Produce a fix plan: identify the exact files and lines that need to change, and what the change should be. Do not apply the change yourself.
 
-4. After fix is complete, escalate directly to the user to request PR approval — do not route through the master agent. Send the master agent a copy of the fix report for its records.
+4. Submit your report (including the fix plan) to the master agent following the format in `docs/testing/report_format.md`. The master agent will apply the changes, commit, and push.
 
 # Report Extension
 

--- a/load_testing/CLAUDE.md
+++ b/load_testing/CLAUDE.md
@@ -6,9 +6,9 @@ You job is to run higher level testing according to the user specification, whic
 
 Read anywhere within `load_testing/` and all its subfolders (including `integration/` and `locust/`).
 
-# editing scope
+# Write / Commit / Push Policy
 
-Only write within `load_testing/` root. Do not edit files inside `integration/` or `locust/` — those are owned by their respective subagents.
+**Read-only agent.** You must not write, edit, create, or delete any file. You must not run `git commit`, `git push`, or create PRs. All file changes are performed exclusively by the master agent after reviewing your report.
 
 # Local vs Remote
 
@@ -57,8 +57,8 @@ If integration tests fail, stop and report to the user before proceeding to load
 # Tasks
 
 1. Before running tests, verify the seed snapshot matches the requirements in `docs/testing/load_testing.md` — specifically: 1,000 purchase receipts pre-seeded under a single user account. If the snapshot does not match (wrong record count, missing user, schema mismatch), stop and escalate to the user — do not proceed with tests until the user approves a seed rebuild.
-2. Receive reports from subagents about test results and fix plans. After each fix cycle, propose additions to the relevant CLAUDE.md (e.g. `docs/CICD/railway/KNOWN_ISSUES.md` for Railway infra patterns, subagent CLAUDE.md for test-specific lessons). Present the proposed additions to the user for approval before writing them.
-3. Only let the subagents to perform the fixing of testing codes and also the testing plans in docs/testing.
+2. Receive reports from subagents about test results and fix plans. After each fix cycle, propose additions to the relevant CLAUDE.md (e.g. `docs/CICD/railway/KNOWN_ISSUES.md` for Railway infra patterns, subagent CLAUDE.md for test-specific lessons). Forward the proposed additions to the master agent — do not write them yourself.
+3. Collect fix plans from subagents and forward them to the master agent for implementation. Subagents do not edit files.
 4. If code needs to be fixed outside of test — business code or service setup — report to master agent.
 
 # escalation rule

--- a/load_testing/integration/CLAUDE.md
+++ b/load_testing/integration/CLAUDE.md
@@ -9,13 +9,9 @@ load_testing/
 
 docs/testing
 
-# editing scope
+# Write / Commit / Push Policy
 
-Only write in this folder
-
-load_testing/integration/
-
-docs/testing
+**Read-only agent.** You must not write, edit, create, or delete any file. You must not run `git commit`, `git push`, or create PRs. All file changes are performed exclusively by the master agent after reviewing your report.
 
 # Honeycomb Setup
 
@@ -62,10 +58,9 @@ Include the environment in your report extension.
 5. Determine if the issue is in test code (your edit scope) or service code (outside scope).
    - **Test code issue:**
      1. Investigate all log sources in order: cloud provider logs (e.g. Railway, Azure) → CI logs → source code
-     2. Propose a fix plan and report to the user — wait for explicit approval before making any changes
-     3. Once approved, execute the plan autonomously. You may self-correct minor issues discovered during iteration without re-escalating
-     4. Rerun the tests to verify the fix. If the bug still exists and the approved plan is exhausted, stop and re-escalate with a new strategy proposal — do not retry indefinitely
-   - **Service code issue:** do not touch service files. Report to master using the Service Bug extension format below.
+     2. Produce a fix plan: identify the exact files and lines that need to change, and what the change should be
+     3. Report the fix plan to the master agent — do not apply the change yourself
+   - **Service code issue:** Report to master using the Service Bug extension format below.
 
 6. Submit report using `docs/testing/report_format.md` as the required skeleton — all sections defined there are mandatory. Use `docs/testing_reports/integration/template.md` as the content guide for how to fill in each section for integration tests specifically.
 

--- a/load_testing/locust/CLAUDE.md
+++ b/load_testing/locust/CLAUDE.md
@@ -9,13 +9,9 @@ load_testing/
 
 docs/testing
 
-# editing scope
+# Write / Commit / Push Policy
 
-Only write in this folder
-
-load_testing/locust
-
-docs/testing
+**Read-only agent.** You must not write, edit, create, or delete any file. You must not run `git commit`, `git push`, or create PRs. All file changes are performed exclusively by the master agent after reviewing your report.
 
 # Honeycomb Setup
 
@@ -57,16 +53,16 @@ Run `/honeycomb-setup` once per session.
 
 6. After a revision, only re-run the test group that contained the failing test — do not re-run the full suite.
 
-7. If nothing is wrong, generate a report in the same format as in docs/testing_reports/load/week1 report.md as the template, with title as locust_report_{timestamp}.md
+7. If nothing is wrong, prepare a report following the format in `docs/testing_reports/load/run1 report.md` as the template. Output the full report content in your response to the master agent with the intended filename `locust_report_{timestamp}.md` — the master agent will write the file.
 
-8. Honeycomb is considered "on" if all three prerequisites from the root `CLAUDE.md` Tracing Prerequisites section are met: (1) `honeycomb` MCP is connected, (2) `OTEL_EXPORTER_OTLP_HEADERS` is set in root `.env`, (3) `HONEYCOMB_API_KEY` is set in `load_testing/.env`. If all three are present, present the test run_id and report back to the master agent. Let it run a honeycomb subagent to check honeycomb and write same report. Titled as honeycomb_report_{timestamp}.md. If you are unsure which query to run, stop and ask the user before proceeding.
+8. Honeycomb is considered "on" if all three prerequisites from the root `CLAUDE.md` Tracing Prerequisites section are met: (1) `honeycomb` MCP is connected, (2) `OTEL_EXPORTER_OTLP_HEADERS` is set in root `.env`, (3) `HONEYCOMB_API_KEY` is set in `load_testing/.env`. If all three are present, include the test run_id in your report to the master agent so it can run Honeycomb queries and write the `honeycomb_report_{timestamp}.md` file itself. If you are unsure which query to run, stop and ask the user before proceeding.
 
 
 
 # Report Extension
 
-Use `docs/testing/report_format.md` as the required skeleton — all sections defined there are mandatory. Use `docs/testing_reports/load/week1 report.md` as the content guide for how to fill in each section for load tests specifically.
-Generate full report file at: `docs/testing_reports/load/locust_report_{timestamp}.md`
+Use `docs/testing/report_format.md` as the required skeleton — all sections defined there are mandatory. Use `docs/testing_reports/load/run1 report.md` as the content guide for how to fill in each section for load tests specifically.
+Output the full report content in your response to the master agent with the intended path `docs/testing_reports/load/locust_report_{timestamp}.md` — the master agent will write the file.
 
 Under `### Extension` include:
 


### PR DESCRIPTION
## Summary

- All subagents (service, testing master, integration, locust, cicd) are now **read-only**
- Subagents investigate, analyze, and produce fix plans / report content, then hand everything back to the master agent
- Only the master agent writes files, commits, and pushes
- Removes all `editing scope` sections from subagent CLAUDE.md files and replaces with explicit `Write / Commit / Push Policy` blocks
- Adds master-only write rule to root CLAUDE.md under `# Agent Role`
- Fixes stale `week1 report.md` → `run1 report.md` reference in locust CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)