### PR TITLE
docs: add CHANGE_LOG.md to each docs subfolder + maintenance rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,21 @@ Only the master agent may write files, run `git commit`, `git push`, or create/m
 
 Subagents are **read-only**. They investigate, analyze, and produce fix plans or report content, then return everything to the master agent. The master agent reviews, applies all changes, commits, and pushes.
 
+## Knowledge Base and Change Logs
+
+Each `docs/` subfolder (except `docs/testing_reports/`) has a `CHANGE_LOG.md`. The master agent must update the relevant changelog(s) as part of any PR that contains a design decision or important code change affecting that folder's domain.
+
+**What to log:** design decisions, architecture changes, strategy shifts, significant behavioural changes.
+**What not to log:** routine test report additions, typo fixes, minor wording updates.
+
+Changelog format — append a new row to the table:
+
+```
+| YYYY-MM-DD | #PR | One-line description of what changed | Why it was decided |
+```
+
+Changelogs may reference entries in `docs/testing_reports/` for supporting evidence but do not duplicate report content.
+
 Please scan the subfolders at most 2 levels for other CLAUDE.md for definition of subagents.
 
 Please also revisit the README.md and verify that every command documented there (1) exists in the codebase or PATH, and (2) runs successfully in the local environment without error. Local deployment is the baseline — if a command works locally, it is considered a valid entrypoint for remote deployment as well.

--- a/docs/CICD/CHANGE_LOG.md
+++ b/docs/CICD/CHANGE_LOG.md
@@ -1,0 +1,17 @@
+# CI/CD Change Log
+
+Design decisions and significant infrastructure changes. Routine report additions are not logged here — see `docs/testing_reports/` for run history.
+
+| Date | PR | Change | Reason |
+|---|---|---|---|
+| 2026-03-15 | #33 | Added PostgreSQL support to CI pipeline | Production target requires PostgreSQL; SQLite is local-dev only |
+| 2026-03-16 | #41 | Added OTel tracing + Honeycomb export to service | Need distributed tracing for load test diagnostics and production observability |
+| 2026-03-22 | #51 | Added integration test job to CI | Catch HTTP-level regressions before load testing; faster feedback than load tests |
+| 2026-03-23 | #52 | Added seed guardrail check before every test run | Prevent tests from running against wrong DB state; avoids false passes on stale data |
+| 2026-03-26 | #72 | Added Azure Container Apps ephemeral load-test environment via Terraform | Validate service on a second cloud provider; ACI swapped for Container Apps to match Railway's scale-to-zero model |
+| 2026-03-26 | #83 | Switched Railway load-test DB to PostgreSQL via PgBouncer (session mode) | SQLite cannot scale horizontally; PgBouncer prevents connection exhaustion under stress load |
+| 2026-03-26 | #83 | Reverted Railway load-test to 1 replica; serialized runs per provider | 2-replica run caused cross-provider concurrency conflicts and resource contention during seeding |
+| 2026-03-26 | #83 | Added `replicas` workflow input; upsert numReplicas in railway.toml | Allows controlled replica scaling experiments without hardcoding values in the workflow |
+| 2026-03-28 | #89 | Added pre-merge branch sync check rule to CLAUDE.md | Prevent merging stale branches; enforces `git fetch + git log HEAD..origin/<base>` before every merge |
+| 2026-03-28 | #91 | Subagents made read-only; only master agent writes/commits/pushes | Prevent concurrent file mutations from multiple agents; single write path simplifies audit trail |
+| 2026-03-28 | #93 | Added multi-agent fix coordination rules | Define conflict detection, one-fix-at-a-time sequencing, and priority order for simultaneous subagent reports |

--- a/docs/api/CHANGE_LOG.md
+++ b/docs/api/CHANGE_LOG.md
@@ -1,0 +1,12 @@
+# API Change Log
+
+Design decisions and significant API changes. See `docs/api/api.yaml` for the current spec.
+
+| Date | PR | Change | Reason |
+|---|---|---|---|
+| 2026-02-28 | #16 | Switched auth from OAuth2 to JWT | Simpler stateless token validation; epoch time used in DB for consistency |
+| 2026-02-28 | #13 | Added persistent refresh token storage | Foundation for future Redis-backed session sharing across replicas |
+| 2026-02-28 | #18 | Added receipt + meta field CRUD endpoints; flattened receipt format | Flattening removes unnecessary nesting; admin control moved into each handler |
+| 2026-03-15 | #33 | All endpoints backed by PostgreSQL in addition to SQLite | Both backends must satisfy identical interface; `$N` placeholders for PostgreSQL, `?` for SQLite |
+| 2026-03-15 | #34 | Added page-number-based pagination to all list endpoints | Prevent unbounded result sets under load; consistent cursor model across resources |
+| 2026-03-16 | #41 | Added OTel span instrumentation to all HTTP handlers | Enables per-endpoint latency tracing in Honeycomb; `test.run_id` forwarded as span attribute for test correlation |

--- a/docs/data/CHANGE_LOG.md
+++ b/docs/data/CHANGE_LOG.md
@@ -1,0 +1,11 @@
+# Data Change Log
+
+Design decisions and significant data model changes. See `docs/data/data_format.md` for current schema.
+
+| Date | PR | Change | Reason |
+|---|---|---|---|
+| 2026-02-28 | #18 | Flattened receipt format; moved admin control into handlers | Nesting added complexity with no benefit; flat schema easier to query and extend |
+| 2026-02-28 | #13 | Added persistent token table | Refresh tokens need to survive restarts; placeholder for future Redis migration |
+| 2026-03-12 | #32 | Clarified extra fields / meta field semantics with examples | Field naming was ambiguous; examples added to prevent misuse by API consumers |
+| 2026-03-15 | #33 | Added PostgreSQL schema alongside SQLite | Production target is PostgreSQL; both schemas must remain behaviourally identical — no SQLite-only features |
+| 2026-03-15 | #34 | Added pagination metadata to list response shape | Clients need total count + page info to render paginated UIs without extra requests |

--- a/docs/testing/CHANGE_LOG.md
+++ b/docs/testing/CHANGE_LOG.md
@@ -1,0 +1,14 @@
+# Testing Change Log
+
+Design decisions and significant testing strategy changes. Individual run results are in `docs/testing_reports/`.
+
+| Date | PR | Change | Reason |
+|---|---|---|---|
+| 2026-03-17 | #44 | Added token-pool-driven logout group (Group 5) | Pre-generating tokens avoids polluting login latency during logout stress |
+| 2026-03-22 | #51 | Added pytest integration test suite covering all 15 endpoints | Catch HTTP-level regressions fast before running expensive load tests; tests run in CI on every PR |
+| 2026-03-23 | #52 | Added seed guardrail script; runs automatically before every load test | Prevent load tests from running against wrong DB state (wrong record count, missing user, schema mismatch) |
+| 2026-03-26 | #83 | Adopted Railway + PostgreSQL as the primary remote load-test target | SQLite cannot validate production-scale behaviour; Railway PgBouncer provides realistic connection-pool pressure |
+| 2026-03-26 | #83 | Added PgBouncer session-mode connection pooling to load-test environment | Prevents connection exhaustion under stress; `SetMaxOpenConns(10)` / `SetMaxIdleConns(5)` validated as safe headroom — see `docs/testing_reports/load/run2-buggy railway - 20260327_011016.md` |
+| 2026-03-26 | manual | Removed Group 5 (logout) from load test suite | Token-pool approach added complexity without proportional signal; logout is covered by integration tests |
+| 2026-03-28 | #87 | Renamed load test reports from `weekN` to `runN`; added `-railway` + timestamps to run2–4 | Week numbering implied time-box; run numbering is more accurate. Timestamps enable direct correlation with CI artifacts |
+| 2026-03-28 | #91 | Subagents made read-only; master agent owns all writes | Single write path prevents concurrent mutations; subagents return analysis and fix plans only |


### PR DESCRIPTION
## Summary

- Creates `CHANGE_LOG.md` in `docs/CICD/`, `docs/api/`, `docs/data/`, `docs/testing/`
- Each seeded with real historical decisions from git history (back to first commit)
- `docs/testing_reports/` intentionally excluded — individual reports are the record there, changelogs may reference them
- Adds rule to root `CLAUDE.md`: master agent appends a changelog row for any PR with a design decision or important code change

## What gets logged
Design decisions, architecture changes, strategy shifts, significant behavioural changes — not routine report additions or minor fixes.

## Format
`| Date | PR | Change | Reason |`

🤖 Generated with [Claude Code](https://claude.com/claude-code)