### PR TITLE
docs: add merge strategy rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,15 @@ These rules govern how much agents can act independently versus when they must s
 
 PLEASE ALWAYS CHECK IF BRANCH IS UP TO DATE WITH TARGET IF YOU HAVE A PR!!!
 
+## Merge strategy
+
+| PR direction | Strategy | Command flag | Reason |
+|---|---|---|---|
+| feature branch → `develop` | Squash | `--squash` | Collapses noisy work-in-progress commits into one clean entry |
+| `develop` → `main` | Merge commit | `--merge` | Preserves shared commit lineage so future develop→main PRs are always clean; squashing here creates diverged histories that cause conflicts |
+
+Never use `--squash` for `develop` → `main`.
+
 ## Pre-merge branch sync check
 
 Before merging any PR (to `develop` or `main`), run:


### PR DESCRIPTION
## Summary

Adds explicit merge strategy rule to root `CLAUDE.md`:

- **feature → develop**: `--squash` (clean up WIP commits)
- **develop → main**: `--merge` (preserve lineage, avoid diverged history)

Prevents the squash-divergence problem that caused develop/main conflicts earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)