### PR TITLE
ci: replace paths-ignore with job-level if for docs-only skip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,19 +3,35 @@ name: Build
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.check.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect source changes
+        id: check
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
+               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Docker Build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,19 +3,35 @@ name: Code Quality
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.check.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect source changes
+        id: check
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
+               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Linting & Format Check
     runs-on: ubuntu-latest
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,19 +3,35 @@ name: Security
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.check.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect source changes
+        id: check
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
+               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   security:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Vulnerability Scan
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,19 +3,35 @@ name: Test
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.check.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect source changes
+        id: check
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
+               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -29,6 +45,8 @@ jobs:
       run: go test -v ./...
 
   test-race:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

PR #112 added `paths-ignore` to 4 CI workflows to skip heavy checks for docs-only PRs. This broke branch protection.

`paths-ignore` at the trigger level causes the workflow to **not fire at all** when all changed files match the ignore patterns. GitHub's branch protection sees the required check names as never reported ("Expected but not run") and blocks the merge — even though no check actually failed.

This is why PR #111 (`docs/run5-azure-report` → `main`) cannot be merged: `test`, `test-race`, `Linting & Format Check`, `Vulnerability Scan`, and `Docker Build` never appear.

## Fix

Remove `paths-ignore` from all 4 workflow triggers (`build.yml`, `test.yml`, `code-quality.yml`, `security.yml`). Add a `changes` job to each that detects whether any non-docs files changed. All other jobs use `if: needs.changes.outputs.src == 'true'`.

When that `if` evaluates to `false`, GitHub Actions marks the job as **"skipped"** — which GitHub branch protection treats as a passing required check. The check name still appears, just with `skipped` conclusion.

**Trigger-level `paths-ignore`:** workflow doesn't run → check never reported → merge blocked ❌  
**Job-level `if`:** workflow runs, jobs skipped → check reported as `skipped` → merge allowed ✅

## After merging

This fix needs to land on `main` (via a follow-up `develop` → `main` PR) before PR #111 can be unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)