### PR TITLE
fix(ci): unify Railway concurrency group to prevent load test / integration test overlap

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,8 +21,10 @@ jobs:
 
     # All runs share the load-test Railway environment — serialize to prevent
     # concurrent deploys and test data conflicts.
+    # NOTE: must match the Railway load-test concurrency group in load-tests.yml
+    # so integration tests and load tests can never overlap and corrupt the shared DB.
     concurrency:
-      group: load-test-env
+      group: railway-load-test-env
       cancel-in-progress: false
 
     steps:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -47,8 +47,10 @@ jobs:
     # Serialize per provider — both Railway and Azure load tests share the same
     # environment resources (PostgreSQL, replicas). Parallel runs would corrupt data
     # and hit connection limits. workflow_dispatch is manual so pile-ups are rare.
+    # NOTE: Railway load tests use the same group as integration-tests.yml so they
+    # can never overlap and corrupt the shared load-test DB mid-run.
     concurrency:
-      group: ${{ inputs.provider }}-load-test
+      group: ${{ inputs.provider == 'railway' && 'railway-load-test-env' || 'azure-load-test' }}
       cancel-in-progress: false
 
     steps:


### PR DESCRIPTION
## Root Cause

Diagnosed via Honeycomb traces + PostgreSQL FK violation logs from run4 (2026-03-27).

`load-tests.yml` used concurrency group `railway-load-test` while `integration-tests.yml` used `load-test-env` — two different names, so GitHub Actions treated them as **independent queues**. A push to `develop` during a load test triggered the integration workflow, which ran `DELETE FROM users WHERE role != 'admin'` mid-run, wiping the seeded test user.

**PostgreSQL proof from run4 burst window (05:52:42 UTC):**
```
ERROR: insert or update on table "refresh_tokens" violates foreign key constraint "refresh_tokens_user_id_fkey"
DETAIL: Key (user_id)=(33bd72ad-b5d5-4291-8187-e0d12ed3b9fa) is not present in table "users".
```
The 434 × HTTP 401 ("user not found") and 75 × HTTP 500 (FK violation on token insert) were caused by this deletion, not by PgBouncer connection recycling as the original run4 report concluded.

## Fix

Both workflows now use `railway-load-test-env` for Railway, forcing them into the same GitHub Actions concurrency queue.

Azure load tests keep `azure-load-test` — they use separate infrastructure and don't share the Railway DB.

## Test plan

- [ ] Merge to `develop`
- [ ] Trigger load test run 6 (Railway) — `cpu_bound/moderate` should complete with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)