### PR TITLE
ci: extract shared changes detection into reusable workflow + fix docs PR skip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,26 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
-    outputs:
-      src: ${{ steps.check.outputs.src }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Detect source changes
-        id: check
-        run: |
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
-               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "src=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-source-changes.yml
 
   build:
     needs: changes

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,26 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
-    outputs:
-      src: ${{ steps.check.outputs.src }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Detect source changes
-        id: check
-        run: |
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
-               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "src=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-source-changes.yml
 
   lint:
     needs: changes

--- a/.github/workflows/detect-source-changes.yml
+++ b/.github/workflows/detect-source-changes.yml
@@ -1,0 +1,51 @@
+name: Detect Source Changes
+
+# Reusable workflow — called by other workflows via `uses:` to avoid
+# duplicating the docs-only skip logic. Exposes a single output: `src`.
+#
+# Usage in a calling workflow:
+#   jobs:
+#     changes:
+#       uses: ./.github/workflows/detect-source-changes.yml
+#     my-job:
+#       needs: changes
+#       if: needs.changes.outputs.src == 'true'
+
+on:
+  workflow_call:
+    outputs:
+      src:
+        description: "'true' if non-docs source files changed; always 'true' on push events"
+        value: ${{ jobs.changes.outputs.src }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.check.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed for the three-dot diff below
+
+      - name: Detect source changes
+        id: check
+        run: |
+          # Push events have no GITHUB_BASE_REF to diff against, so assume
+          # something changed and run everything. Direct pushes to protected
+          # branches are blocked by branch protection, so this path is rarely hit.
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For PRs: compare the PR branch against the base branch.
+          # grep -v inverts the match — it exits 0 (true) if ANY file does NOT
+          # match the docs/specs/markdown pattern, meaning a source file changed.
+          # If every changed file is docs/specs/*.md, grep -v exits 1 → src=false.
+          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
+               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,20 +2,22 @@ name: Integration Tests
 
 on:
   pull_request:
-    branches: [ develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
+    # Trigger on PRs to both develop and main so the `integration` required
+    # status check is always reported — even for docs-only PRs to main.
+    # The changes job below skips the actual work when no source files changed.
+    branches: [ develop, main ]
   push:
+    # Push to develop (e.g. after a PR merge) — changes job always returns
+    # src=true for push events, so integration runs on every code push.
     branches: [ develop ]
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
-      - '**.md'
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-source-changes.yml
+
   integration:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,26 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
-    outputs:
-      src: ${{ steps.check.outputs.src }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Detect source changes
-        id: check
-        run: |
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
-               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "src=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-source-changes.yml
 
   security:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,26 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
-    outputs:
-      src: ${{ steps.check.outputs.src }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Detect source changes
-        id: check
-        run: |
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD \
-               | grep -qvE '^(docs/|specs/|.*\.md$)'; then
-            echo "src=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "src=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-source-changes.yml
 
   test:
     needs: changes


### PR DESCRIPTION
## Summary

- **Fixes stuck docs PRs to main**: `integration-tests.yml` used `paths-ignore` which suppresses the workflow entirely — GitHub's required `integration` status check was never reported, blocking docs-only PRs to main indefinitely. Switched to the `changes` job pattern (fires the workflow, skips the job) so the check always reports a SKIPPED status.
- **Adds `main` to integration-tests.yml trigger**: The workflow now triggers on PRs to both `develop` and `main`. Docs PRs to main skip via the changes job; code PRs to main run the full suite.
- **Deduplicates the docs-only skip logic**: Extracted the identical 15-line `changes` job (git diff + grep pattern) into a reusable workflow at `.github/workflows/detect-source-changes.yml`. Removed the copy-pasted block from `build.yml`, `test.yml`, `code-quality.yml`, `security.yml`, and `integration-tests.yml` — one place to update if the filter pattern changes.

## Test plan

- [ ] Open a docs-only PR to main and verify `integration` check reports SKIPPED (not stuck as Expected)
- [ ] Open a code PR to develop and verify all checks run normally
- [ ] Verify the `changes` job in each affected workflow resolves correctly via the reusable workflow output

🤖 Generated with [Claude Code](https://claude.com/claude-code)