### PR TITLE
docs: add guardrail for remote load test execution

### DIFF
--- a/load_testing/CLAUDE.md
+++ b/load_testing/CLAUDE.md
@@ -25,8 +25,16 @@ Before running any tests locally:
 3. If the service is already running and healthy, skip restore and startup — do not restart unnecessarily
 
 ## Remote test setup
-Do not touch local service or snapshot.
-Verify the remote service is healthy before running tests: `curl -sf {GYD_TARGET_URL}/health`
+**Railway and Azure load tests are always triggered via GitHub Actions — never run locally.**
+Before doing anything else for a remote test, check `.github/workflows/load-tests.yml` to understand how to trigger it.
+The correct command is:
+```bash
+gh workflow run load-tests.yml --ref <branch> -f provider=railway -f group=all -f phase=moderate
+```
+Do NOT attempt to create or populate `load_testing/.env` for remote tests — credentials are stored in GitHub Secrets and injected by CI.
+Do NOT look up Railway variables or hunt for credentials locally.
+
+Verify the remote service is healthy before triggering the workflow: `curl -sf {GYD_TARGET_URL}/health`
 If the health check fails, stop and report to the user — do not proceed.
 
 ## Remote seeding strategy

--- a/load_testing/locust/CLAUDE.md
+++ b/load_testing/locust/CLAUDE.md
@@ -70,7 +70,10 @@ If any regression case matches the current results, treat it as a test failure �
 
 ## Load Testing Workflow
 
-Always use `docker compose` to run the service for load testing. Never use the local binary.
+**Remote tests (Railway, Azure) are triggered via GitHub Actions — never run locally.**
+Use `gh workflow run load-tests.yml` (see `.github/workflows/load-tests.yml`). Do not create `load_testing/.env` or look up credentials for remote runs — CI injects them from GitHub Secrets.
+
+For local tests, always use `docker compose` to run the service. Never use the local binary.
 
 The testing master handles service startup and snapshot restore before delegating to this agent.
 Do not restart the service yourself — assume it is already running and healthy when you start.


### PR DESCRIPTION
## Summary
- Agents were incorrectly trying to run Railway load tests locally (creating `.env`, fetching Railway variables) instead of using GitHub Actions
- Added explicit rules to `load_testing/CLAUDE.md` and `load_testing/locust/CLAUDE.md` to prevent recurrence

## Changes
- `load_testing/CLAUDE.md`: Remote test setup section now states clearly to use `gh workflow run`, not local setup; do not create `.env` or look up credentials
- `load_testing/locust/CLAUDE.md`: Same rule added to Load Testing Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)