### PR TITLE
fix: atomic token rotation — prevent concurrent refresh race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 
 require (
 	github.com/XSAM/otelsql v0.41.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelslog v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/XSAM/otelsql v0.41.0 h1:uZifjQhZhv5EDYJh+IVk1DiYxQZJBlNSen0MBFnfxB8=
 github.com/XSAM/otelsql v0.41.0/go.mod h1:NMQT0PiKoFILp9QgjQz+D5mvW+9mT0suR7OejqrtMaM=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
@@ -166,6 +168,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -37,6 +37,11 @@ type RefreshTokenStore interface {
 	// Find returns the userID for a valid, non-expired token.
 	// Returns ("", model.ErrInvalidToken) if not found or expired.
 	Find(ctx context.Context, token string) (userID string, err error)
+	// Consume atomically validates and deletes the token in a single operation.
+	// Returns the userID on success, or ErrInvalidToken if the token does not exist
+	// or was already consumed by a concurrent call. This prevents the race where two
+	// concurrent refresh requests both pass Find before either calls Delete.
+	Consume(ctx context.Context, token string) (userID string, err error)
 	// Delete revokes a refresh token (logout).
 	Delete(ctx context.Context, token string) error
 	// DeleteAllForUser revokes all refresh tokens for a user (force-logout).
@@ -82,8 +87,10 @@ func (ts *TokenService) ValidateAccessToken(tokenStr string) (*Claims, error) {
 
 // RefreshAccessToken validates a refresh token and issues a new access token.
 // The old refresh token is consumed and a new one is issued (rotation).
+// Consume is used instead of Find+Delete to prevent a race where two concurrent
+// calls both pass Find before either reaches Delete.
 func (ts *TokenService) RefreshAccessToken(ctx context.Context, refreshToken string, users UserLookup) (newAccess, newRefresh string, err error) {
-	userID, err := ts.store.Find(ctx, refreshToken)
+	userID, err := ts.store.Consume(ctx, refreshToken)
 	if err != nil {
 		return "", "", ErrInvalidToken
 	}
@@ -93,10 +100,6 @@ func (ts *TokenService) RefreshAccessToken(ctx context.Context, refreshToken str
 		return "", "", ErrInvalidToken
 	}
 
-	// Rotate: delete old token, issue new pair.
-	if err = ts.store.Delete(ctx, refreshToken); err != nil {
-		return "", "", err
-	}
 	return ts.IssueTokenPair(ctx, user)
 }
 

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -230,6 +230,44 @@ func TestRefreshAccessToken_OldTokenRevoked(t *testing.T) {
 	}
 }
 
+func TestRefreshAccessToken_ConcurrentSameToken(t *testing.T) {
+	env := newTestTokenEnv(t)
+	user := newSavedUser(t, env.svc, model.RoleUser)
+
+	_, refresh, err := env.tokens.IssueTokenPair(context.Background(), user)
+	if err != nil {
+		t.Fatalf("IssueTokenPair failed: %v", err)
+	}
+
+	type result struct {
+		err error
+	}
+	results := make(chan result, 2)
+
+	for range 2 {
+		go func() {
+			_, _, e := env.tokens.RefreshAccessToken(context.Background(), refresh, env.svc)
+			results <- result{err: e}
+		}()
+	}
+
+	r1, r2 := <-results, <-results
+	successes := 0
+	invalids := 0
+	for _, r := range []result{r1, r2} {
+		if r.err == nil {
+			successes++
+		} else if errors.Is(r.err, auth.ErrInvalidToken) {
+			invalids++
+		} else {
+			t.Errorf("unexpected error: %v", r.err)
+		}
+	}
+	if successes != 1 || invalids != 1 {
+		t.Errorf("expected exactly 1 success and 1 ErrInvalidToken, got %d successes and %d invalids", successes, invalids)
+	}
+}
+
 func TestRefreshAccessToken_InvalidToken(t *testing.T) {
 	env := newTestTokenEnv(t)
 

--- a/internal/repository/postgres/refresh_token.go
+++ b/internal/repository/postgres/refresh_token.go
@@ -48,6 +48,24 @@ func (s *RefreshTokenStore) Find(ctx context.Context, token string) (string, err
 	return userID, nil
 }
 
+// Consume atomically deletes the token and returns the userID in one statement.
+// Concurrent callers racing on the same token: exactly one DELETE matches the row;
+// the other finds zero rows and gets ErrInvalidToken.
+func (s *RefreshTokenStore) Consume(ctx context.Context, token string) (string, error) {
+	var userID string
+	err := s.db.conn.QueryRowContext(ctx,
+		`DELETE FROM refresh_tokens WHERE token = $1 AND expires_at > $2 RETURNING user_id`,
+		token, time.Now().Unix(),
+	).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return "", model.ErrInvalidToken
+	}
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
 func (s *RefreshTokenStore) Delete(ctx context.Context, token string) error {
 	_, err := s.db.conn.ExecContext(ctx, `DELETE FROM refresh_tokens WHERE token = $1`, token)
 	return err

--- a/internal/repository/redis/refresh_token.go
+++ b/internal/repository/redis/refresh_token.go
@@ -21,6 +21,17 @@ type RefreshTokenStore struct {
 	client *goredis.Client
 }
 
+// NewWithClient wraps an already-configured Redis client. Used in tests to
+// inject a miniredis-backed client without OTel instrumentation.
+func NewWithClient(client *goredis.Client) (*RefreshTokenStore, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("ping redis: %w", err)
+	}
+	return &RefreshTokenStore{client: client}, nil
+}
+
 // New parses the Redis URL and returns a connected RefreshTokenStore.
 func New(redisURL string) (*RefreshTokenStore, error) {
 	opts, err := goredis.ParseURL(redisURL)
@@ -66,6 +77,21 @@ func (s *RefreshTokenStore) Find(ctx context.Context, token string) (string, err
 	if err != nil {
 		return "", err
 	}
+	return userID, nil
+}
+
+// Consume atomically claims the token using GETDEL. If two goroutines race,
+// only one receives the userID — the other gets Nil and returns ErrInvalidToken.
+// SREM on the user-set is bookkeeping only; it is not security-critical.
+func (s *RefreshTokenStore) Consume(ctx context.Context, token string) (string, error) {
+	userID, err := s.client.GetDel(ctx, rtKey(token)).Result()
+	if errors.Is(err, goredis.Nil) {
+		return "", model.ErrInvalidToken
+	}
+	if err != nil {
+		return "", err
+	}
+	_ = s.client.SRem(ctx, utKey(userID), token).Err()
 	return userID, nil
 }
 

--- a/internal/repository/redis/refresh_token_test.go
+++ b/internal/repository/redis/refresh_token_test.go
@@ -1,0 +1,184 @@
+package redis_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/gatheryourdeals/data/internal/model"
+	redisstore "github.com/gatheryourdeals/data/internal/repository/redis"
+)
+
+// newTestStore spins up a miniredis instance and returns a store backed by it.
+func newTestStore(t *testing.T) (*redisstore.RefreshTokenStore, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	store, err := redisstore.NewWithClient(goredis.NewClient(&goredis.Options{Addr: mr.Addr()}))
+	if err != nil {
+		t.Fatalf("NewWithClient: %v", err)
+	}
+	return store, mr
+}
+
+func TestRedisRefreshTokenStore_SaveAndFind(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	if err := store.Save(ctx, "tok-1", "user-1", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	userID, err := store.Find(ctx, "tok-1")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if userID != "user-1" {
+		t.Errorf("got userID %q, want %q", userID, "user-1")
+	}
+}
+
+func TestRedisRefreshTokenStore_Find_NotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	_, err := store.Find(context.Background(), "nonexistent")
+	if !errors.Is(err, model.ErrInvalidToken) {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestRedisRefreshTokenStore_Find_Expired(t *testing.T) {
+	store, mr := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	if err := store.Save(ctx, "tok-exp", "user-1", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Fast-forward miniredis clock past TTL.
+	mr.FastForward(2 * time.Hour)
+
+	_, err := store.Find(ctx, "tok-exp")
+	if !errors.Is(err, model.ErrInvalidToken) {
+		t.Fatalf("expected ErrInvalidToken for expired token, got %v", err)
+	}
+}
+
+func TestRedisRefreshTokenStore_Delete(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	if err := store.Save(ctx, "tok-1", "user-1", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, "tok-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, err := store.Find(ctx, "tok-1")
+	if !errors.Is(err, model.ErrInvalidToken) {
+		t.Fatalf("expected ErrInvalidToken after delete, got %v", err)
+	}
+}
+
+func TestRedisRefreshTokenStore_DeleteAllForUser(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	for _, tok := range []string{"t1", "t2", "t3"} {
+		if err := store.Save(ctx, tok, "user-1", exp); err != nil {
+			t.Fatalf("Save %q: %v", tok, err)
+		}
+	}
+	if err := store.Save(ctx, "t-other", "user-2", exp); err != nil {
+		t.Fatalf("Save t-other: %v", err)
+	}
+
+	if err := store.DeleteAllForUser(ctx, "user-1"); err != nil {
+		t.Fatalf("DeleteAllForUser: %v", err)
+	}
+
+	for _, tok := range []string{"t1", "t2", "t3"} {
+		if _, err := store.Find(ctx, tok); !errors.Is(err, model.ErrInvalidToken) {
+			t.Errorf("expected %q to be deleted, got %v", tok, err)
+		}
+	}
+	// user-2 token should be untouched.
+	if _, err := store.Find(ctx, "t-other"); err != nil {
+		t.Errorf("user-2 token should survive, got %v", err)
+	}
+}
+
+// --- Consume ---
+
+func TestRedisRefreshTokenStore_Consume_Success(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	if err := store.Save(ctx, "tok-1", "user-1", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	userID, err := store.Consume(ctx, "tok-1")
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if userID != "user-1" {
+		t.Errorf("got userID %q, want %q", userID, "user-1")
+	}
+	// Token must be gone after consume.
+	if _, err := store.Find(ctx, "tok-1"); !errors.Is(err, model.ErrInvalidToken) {
+		t.Errorf("token should be gone after Consume, got %v", err)
+	}
+}
+
+func TestRedisRefreshTokenStore_Consume_NotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	_, err := store.Consume(context.Background(), "nonexistent")
+	if !errors.Is(err, model.ErrInvalidToken) {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestRedisRefreshTokenStore_Consume_ConcurrentSameToken(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	exp := time.Now().Add(time.Hour)
+	if err := store.Save(ctx, "tok-race", "user-1", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	type result struct{ err error }
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			_, e := store.Consume(ctx, "tok-race")
+			results <- result{err: e}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	successes, invalids := 0, 0
+	for r := range results {
+		if r.err == nil {
+			successes++
+		} else if errors.Is(r.err, model.ErrInvalidToken) {
+			invalids++
+		} else {
+			t.Errorf("unexpected error: %v", r.err)
+		}
+	}
+	if successes != 1 || invalids != 1 {
+		t.Errorf("want 1 success + 1 ErrInvalidToken, got %d + %d", successes, invalids)
+	}
+}

--- a/internal/repository/sqlite/refresh_token.go
+++ b/internal/repository/sqlite/refresh_token.go
@@ -48,6 +48,25 @@ func (s *RefreshTokenStore) Find(ctx context.Context, token string) (string, err
 	return userID, nil
 }
 
+// Consume atomically deletes the token and returns the userID in one statement.
+// If the token is missing or expired, sql.ErrNoRows maps to ErrInvalidToken.
+// Because SQLite serialises writers, the DELETE is the exclusive "claim" — a
+// concurrent call that races here will find no rows and get ErrInvalidToken.
+func (s *RefreshTokenStore) Consume(ctx context.Context, token string) (string, error) {
+	var userID string
+	err := s.db.conn.QueryRowContext(ctx,
+		`DELETE FROM refresh_tokens WHERE token = ? AND expires_at > ? RETURNING user_id`,
+		token, time.Now().Unix(),
+	).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return "", model.ErrInvalidToken
+	}
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
 func (s *RefreshTokenStore) Delete(ctx context.Context, token string) error {
 	_, err := s.db.conn.ExecContext(ctx, `DELETE FROM refresh_tokens WHERE token = ?`, token)
 	return err

--- a/internal/repository/sqlite/sqlite.go
+++ b/internal/repository/sqlite/sqlite.go
@@ -43,6 +43,13 @@ func (db *DB) Close() error {
 	return db.conn.Close()
 }
 
+// SetMaxOpenConns forwards to the underlying sql.DB. Useful in tests that use
+// an in-memory SQLite database: :memory: is per-connection, so pinning to one
+// connection ensures all goroutines share the same database.
+func (db *DB) SetMaxOpenConns(n int) {
+	db.conn.SetMaxOpenConns(n)
+}
+
 // migrate runs all pending goose migrations from the embedded SQL files.
 // follwing example in https://github.com/pressly/goose?tab=readme-ov-file#go-migrations
 func (db *DB) migrate() error {

--- a/internal/repository/sqlite/testutil/testutil.go
+++ b/internal/repository/sqlite/testutil/testutil.go
@@ -8,12 +8,16 @@ import (
 
 // NewTestDB creates a temporary in-memory SQLite database for testing.
 // It runs migrations automatically and closes the database when the test finishes.
+// MaxOpenConns is set to 1 because :memory: databases are per-connection in
+// SQLite — without this, concurrent goroutines may get a second connection
+// that sees an empty database (no tables).
 func NewTestDB(t *testing.T) *sqlite.DB {
 	t.Helper()
 	db, err := sqlite.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create test database: %v", err)
 	}
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 	return db
 }

--- a/load_testing/integration/test_endpoints.py
+++ b/load_testing/integration/test_endpoints.py
@@ -129,6 +129,34 @@ def test_refresh_success(config, user_token_pair):
     assert "refresh_token" in body
 
 
+def test_refresh_concurrent_same_token(config, user_token_pair):
+    """Two simultaneous refresh requests with the same token: exactly one 200, one 401."""
+    import threading
+
+    token = user_token_pair["refresh_token"]
+    payload = {"refresh_token": token}
+    url = f"{config['base_url']}/api/v1/auth/refresh"
+
+    responses = []
+    lock = threading.Lock()
+
+    def do_refresh():
+        resp = requests.post(url, json=payload, timeout=30)
+        with lock:
+            responses.append(resp.status_code)
+
+    t1 = threading.Thread(target=do_refresh)
+    t2 = threading.Thread(target=do_refresh)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert sorted(responses) == [200, 401], (
+        f"expected [200, 401] from concurrent refresh, got {sorted(responses)}"
+    )
+
+
 def test_refresh_invalid_token(config):
     resp = requests.post(
         f"{config['base_url']}/api/v1/auth/refresh",


### PR DESCRIPTION
## Summary

- **Root cause**: `RefreshAccessToken` called `Find` then `Delete` as two separate steps. Two concurrent requests with the same token both passed `Find` before either reached `Delete`, causing both to issue new token pairs (token rotation violated).
- **Fix**: new `Consume` method on `RefreshTokenStore` interface that atomically claims and deletes in one operation. Only one concurrent caller wins; the other gets `ErrInvalidToken`.
- **Implementations**: `DELETE ... RETURNING user_id` for SQLite/Postgres; `GETDEL` for Redis (atomic claim on `rt:` key, SREM for set bookkeeping).
- **Test infra fix**: pin `testutil.NewTestDB` to `MaxOpenConns(1)` — `:memory:` SQLite is per-connection, so concurrent goroutines were getting empty databases.

## New tests

| Test | Location | What it verifies |
|---|---|---|
| `TestRefreshAccessToken_ConcurrentSameToken` | `internal/auth/jwt_test.go` | Two goroutines, same token → exactly 1 success, 1 ErrInvalidToken |
| `TestRedisRefreshTokenStore_Consume_ConcurrentSameToken` | `internal/repository/redis/refresh_token_test.go` | Redis GETDEL race — same assertion at store level |
| `TestRedisRefreshTokenStore_*` (8 tests) | `internal/repository/redis/refresh_token_test.go` | First Redis store unit tests (backed by miniredis) |
| `test_refresh_concurrent_same_token` | `load_testing/integration/test_endpoints.py` | Two threads hit `/refresh` simultaneously → `[200, 401]` |

## Test plan

- [x] `go test ./... -race` — all packages green locally
- [ ] Integration tests via CI (triggered by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)