### PR TITLE
fix: correct back-merge workflow

### DIFF
--- a/.github/workflows/back-merge-main-to-develop.yml
+++ b/.github/workflows/back-merge-main-to-develop.yml
@@ -19,7 +19,7 @@ jobs:
         id: check
         run: |
           git fetch origin
-          BEHIND=$(git log origin/develop..origin/main --oneline | wc -l)
+          BEHIND=$(git rev-list --count origin/develop..origin/main)
           echo "behind=$BEHIND" >> $GITHUB_OUTPUT
           echo "develop is $BEHIND commit(s) behind main"
 
@@ -33,15 +33,9 @@ jobs:
             echo "Back-merge PR already open, skipping."
             exit 0
           fi
+          BODY=$(printf 'Automated back-merge after a direct merge to `main` (e.g. a docs-only PR).\n\nKeeps `develop` in sync so the next `develop` → `main` promotion is clean.\n\n**Merge strategy:** use **Create a merge commit** (not squash).')
           gh pr create \
             --base develop \
             --head main \
             --title "chore: back-merge main → develop" \
-            --body "$(cat <<'EOF'
-Automated back-merge after a direct merge to \`main\` (e.g. a docs-only PR).
-
-Keeps \`develop\` in sync so the next \`develop\` → \`main\` promotion is clean.
-
-**Merge strategy:** use **Create a merge commit** (not squash).
-EOF
-)"
+            --body "$BODY"


### PR DESCRIPTION
## Summary

- **`wc -l` whitespace bug:** replaced with `git rev-list --count` which outputs a clean integer — the old form produced padded output like `      0`, making `!= '0'` always true
- **YAML parse error:** replaced heredoc-inside-double-quote with `printf` to keep all lines properly indented within the block scalar

## Test plan

- [ ] Trigger a docs-only PR merge to `main` and verify the back-merge PR is opened exactly once
- [ ] Verify no spurious PR is opened when `develop` is already in sync with `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)