### PR TITLE
feat(postgres): PgBouncer transaction mode via simple protocol

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -75,7 +75,6 @@ jobs:
             echo "numReplicas = ${{ inputs.replicas }}" >> railway.toml
           fi
           railway up \
-            -p "7639518c-e0a7-4cd4-8227-6c2575458620" \
             -e "load-test" \
             -s "GatherYourDeals-data" \
             --detach

--- a/internal/repository/postgres/postgres.go
+++ b/internal/repository/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+	"net/url"
 
 	"github.com/XSAM/otelsql"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -19,9 +20,28 @@ type DB struct {
 	conn *sql.DB
 }
 
+// withSimpleProtocol appends default_query_exec_mode=simple_protocol to the DSN.
+// Required for PgBouncer transaction mode — prepared statements are not preserved
+// across connections in transaction mode, so pgx must use the simple wire protocol.
+// Safe to apply in session mode too (no functional difference, minor perf overhead).
+func withSimpleProtocol(dsn string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	q := u.Query()
+	q.Set("default_query_exec_mode", "simple_protocol")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
 // New opens a PostgreSQL database at the given DSN and runs migrations.
 // dsn may be a URI (postgres://...) or a key-value DSN (host=... port=...).
 func New(dsn string) (*DB, error) {
+	dsn, err := withSimpleProtocol(dsn)
+	if err != nil {
+		return nil, err
+	}
 	conn, err := otelsql.Open("pgx", dsn,
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{DisableQuery: true}),


### PR DESCRIPTION
## Summary

- Add `withSimpleProtocol()` in `internal/repository/postgres/postgres.go` to inject `default_query_exec_mode=simple_protocol` into the DSN before opening the connection
- Required for PgBouncer **transaction mode** — in transaction mode a backend connection is only held per-transaction, so prepared statements cached on one connection are not available on the next; simple protocol sends full SQL text on every query and avoids this
- Safe to apply unconditionally — simple protocol with session-mode PgBouncer is harmless (minor perf overhead only)
- Remove redundant `-p <project-id>` flag from `railway up` in `load-tests.yml` — `RAILWAY_TOKEN` is project-scoped so the project ID is already implicit

## Test plan

- [ ] Change Railway PgBouncer pool mode to `transaction` in Railway dashboard before running load test
- [ ] Trigger load test via GitHub Actions → Load Tests → Run workflow (provider: railway, group: all)
- [ ] Compare results against run 7 baseline — any heavy degradation indicates a compatibility issue with simple protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)