### PR TITLE
chore: promote develop → main (PgBouncer transaction mode)

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -75,7 +75,6 @@ jobs:
             echo "numReplicas = ${{ inputs.replicas }}" >> railway.toml
           fi
           railway up \
-            -p "7639518c-e0a7-4cd4-8227-6c2575458620" \
             -e "load-test" \
             -s "GatherYourDeals-data" \
             --detach

--- a/docs/testing_reports/load/run8 railway - 20260411_011909.md
+++ b/docs/testing_reports/load/run8 railway - 20260411_011909.md
@@ -1,0 +1,152 @@
+# Summary
+
+This article records the load testing results from run #8, run against the `feat/pgbouncer-transaction-mode` branch on Railway + PostgreSQL.
+
+Service was deployed on Railway (2 replicas, `us-west2`) backed by Railway-managed PostgreSQL via PgBouncer (**transaction mode** — first run with transaction mode enabled) and Redis (refresh token store). Railway platform outage from run 7 has resolved.
+
+**8 of 8 phases passed (0% error rate).** Zero HTTP failures across all groups and phases. Transaction mode is confirmed compatible with the service.
+
+# Environment
+
+- **Platform**: Railway (2 replicas, `us-west2`)
+- **Database**: PostgreSQL (Railway-managed, via PgBouncer in **transaction mode**)
+- **Cache**: Redis (Railway-managed, refresh token store)
+- **Service**: `GatherYourDeals-data` (branch `feat/pgbouncer-transaction-mode`, PR #149)
+- **GitHub Run**: `24271326633` (artifact: `load-test-results-24271326633`)
+- **Results directory**: `load_testing/results/20260411_011909/`
+
+## Changes from Run 7
+
+- PgBouncer pool mode changed from **session** to **transaction** (Railway dashboard)
+- `withSimpleProtocol()` added to `internal/repository/postgres/postgres.go` — injects `default_query_exec_mode=simple_protocol` into the DSN; required for PgBouncer transaction mode (prepared statements are not preserved across connections in transaction mode)
+- Replica count increased from 1 to 2
+- Redundant `-p <project-id>` flag removed from `railway up` in `load-tests.yml`
+
+# Performance Result
+
+**Test run IDs:**
+- cpu_bound/moderate: `11a1dbc3-5528-4b55-ad88-84c52dfe326f` ✓
+- cpu_bound/stress: `fee3d5f7-ac60-4618-a3d7-45fea9c33804` ✓
+- read_heavy/moderate: `f23ce67b-2589-480a-80c8-a90cf5ce8903` ✓
+- read_heavy/stress: `f8a3d1a2-be4d-443a-93f3-0e0443a84753` ✓
+- write_ops/moderate: `cb5f9cf6-0117-4e14-985e-58456fbcd971` ✓
+- write_ops/stress: `b8d59b09-5d95-4428-96e6-c929db95ff94` ✓
+- misc_lightweight/moderate: `3f28b41f-33ec-45f2-b8bc-27e99d2c86d5` ✓
+- misc_lightweight/stress: `217c7c1b-0c7c-4eca-af61-66383cf21484` ✓
+
+**Time Range**: 2026-04-11 01:18 UTC → 01:38 UTC (~20 min total)
+
+## Run Duration
+
+| Group | Phase | Users | Intended (s) | Actual (s) | Notes |
+|---|---|---|---|---|---|
+| cpu_bound | moderate | 100 | 120 | 120.1 | ✓ 0 errors |
+| cpu_bound | stress | 500 | 150 | 150.2 | ✓ 0 errors |
+| read_heavy | moderate | 400 | 120 | 130.9 | ✓ 0 errors (slight overrun, normal) |
+| read_heavy | stress | 2000 | 150 | 151.8 | ✓ 0 errors |
+| write_ops | moderate | 100 | 120 | 120.2 | ✓ 0 errors |
+| write_ops | stress | 500 | 150 | 150.3 | ✓ 0 errors |
+| misc_lightweight | moderate | 110 | 120 | 120.2 | ✓ 0 errors |
+| misc_lightweight | stress | 540 | 150 | 150.1 | ✓ 0 errors |
+
+## Moderate Phase
+
+| Endpoint | Target RPS | Actual RPS | Avg Latency (ms) | P50 / P95 (ms) | # Errors | # Requests |
+|---|---|---|---|---|---|---|
+| POST /api/v1/auth/login | 100 | 29.5 | 3,287 | 3,000 / 5,900 | 0 | 3,513 |
+| GET /api/v1/auth/me | 100 | 84.1 | 181 | 100 / 350 | 0 | 11,104 |
+| GET /api/v1/receipts | 100 | 84.6 | 218 | 130 / 400 | 0 | 11,180 |
+| GET /api/v1/receipts/:id | 100 | 85.5 | 206 | 120 / 390 | 0 | 11,297 |
+| GET /api/v1/meta | 100 | 84.7 | 206 | 130 / 370 | 0 | 11,187 |
+| POST /api/v1/receipts | 200 | 94.4 | 167 | 110 / 350 | 0 | 11,385 |
+| DELETE /api/v1/receipts/:id | 200 | 94.3 | 160 | 110 / 350 | 0 | 11,377 |
+| POST /api/v1/auth/refresh | 100 | 90.5 | 149 | 110 / 330 | 0 | 10,901 |
+| POST /api/v1/meta | 5 | 4.7 | 143 | 110 / 300 | 0 | 568 |
+| PUT /api/v1/meta/:fieldName | 5 | 4.6 | 145 | 100 / 340 | 0 | 556 |
+
+## Stress Phase
+
+| Endpoint | Target RPS | Actual RPS | Avg Latency (ms) | P50 / P95 (ms) | # Errors | # Requests |
+|---|---|---|---|---|---|---|
+| POST /api/v1/auth/login | 500 | 17.7 | 17,391 | 13,000 / 47,000 | 0 | 2,635 |
+| GET /api/v1/auth/me | 500 | 372.0 | 200 | 130 / 750 | 0 | 56,647 |
+| GET /api/v1/receipts | 500 | 367.9 | 324 | 240 / 880 | 0 | 56,022 |
+| GET /api/v1/receipts/:id | 500 | 370.1 | 281 | 200 / 830 | 0 | 56,360 |
+| GET /api/v1/meta | 500 | 367.8 | 322 | 240 / 870 | 0 | 56,013 |
+| POST /api/v1/receipts | 1000 | 373.4 | 226 | 200 / 430 | 0 | 55,813 |
+| DELETE /api/v1/receipts/:id | 1000 | 372.6 | 239 | 230 / 420 | 0 | 55,700 |
+| POST /api/v1/auth/refresh | 500 | 368.3 | 202 | 170 / 430 | 0 | 55,011 |
+| POST /api/v1/meta | 20 | 17.8 | 191 | 160 / 400 | 0 | 2,654 |
+| PUT /api/v1/meta/:fieldName | 20 | 18.3 | 191 | 160 / 400 | 0 | 2,732 |
+
+## Failures
+
+None. All 8 phases returned 0 errors.
+
+# Key Observations
+
+## 1. Transaction mode confirmed compatible — zero errors
+
+Switching PgBouncer to transaction mode with `default_query_exec_mode=simple_protocol` produced no errors or regressions. All 8 phases passed cleanly. The simple protocol change is backward-compatible with session mode (no functional difference, minor prepared-statement cache overhead).
+
+## 2. Login throughput recovered from run 7 outage
+
+`POST /api/v1/auth/login` at moderate achieved **29.5 RPS** (run 7: 18.6 RPS under outage). P50 dropped from 5,300ms to 3,000ms. The improvement is attributable to the Railway platform outage resolving, not the transaction mode change. Login remains bcrypt-bound — the DB query takes 1-3ms while the full request takes 3,000ms P50.
+
+## 3. Transaction mode provides no visible throughput gain at 2 replicas
+
+With `SetMaxOpenConns(10)` and 2 replicas, the service holds at most 20 simultaneous connections to PgBouncer. Railway's PostgreSQL `max_connections` is well above this — session mode was never causing connection contention at this scale. Transaction mode's multiplexing benefit only materialises at higher replica counts (~10+) where the aggregate connection count approaches the PostgreSQL limit.
+
+## 4. misc/stress refresh tail dramatically improved
+
+`POST /api/v1/auth/refresh` at stress: P95 dropped from **3,000ms** (run 7) to **430ms** (run 8). This is the outage effect from run 7 fully resolved — Redis was the bottleneck under outage conditions. P50 is stable at 170ms.
+
+## 5. Trace analysis: DB is not the bottleneck
+
+Honeycomb traces from this run show:
+- `sql.conn.query`: P50=1ms, P95=61ms — queries themselves are fast
+- `sql.conn.exec`: P50=3ms, P95=31ms
+- `sql.connector.connect` (new TCP connections): P50=143ms, P95=363ms — 7,204 events across the full run (~2% of all queries)
+
+The HTTP handler P50 is 30-80ms while DB P50 is 1-3ms. The ~30ms floor is Railway internal network latency. The connection pool is not saturated — raising `SetMaxOpenConns` above 10 would provide no benefit at the current scale.
+
+## 6. Bcrypt + network are the ceiling at current scale
+
+With 2 CPUs per replica:
+- **Login**: bcrypt saturates available CPU. More replicas distribute the hashing load; lower bcrypt cost factor would improve throughput at a security tradeoff.
+- **Reads/writes**: 30ms network floor is fixed by Railway topology. No software-level tuning can reduce it.
+
+# Comparison vs. Previous Runs
+
+| Metric | Run 1 (Local, SQLite) | Run 4 (Railway, PG) | Run 6 (Railway, PG+Redis) | Run 7 (Railway, outage) | Run 8 (Railway, txn mode) |
+|---|---|---|---|---|---|
+| Login P50 (moderate) | 790ms | 2,700ms | 3,400ms | 5,300ms | **3,000ms** |
+| Login actual RPS (moderate) | 93 | 36.45 | 23.75 | 18.6 | **29.5** |
+| Login moderate error rate | 0% | **11.72% (burst)** | 0% | 0% | 0% |
+| Login stress error rate | 0% | n/a | 0% | 0% | 0% |
+| Reads P50 (moderate) | 1–4ms | 70–100ms | 96–260ms | 110–280ms | **100–130ms** |
+| Reads P50 (stress) | 4–110ms | 74–160ms | 96–820ms | 150–470ms | **130–240ms** |
+| Write P50 (moderate) | 1–2ms | 79–81ms | 210–330ms | 120ms | **110ms** |
+| Write P50 (stress) | 2ms | 120–140ms | 200–220ms | 230–260ms | **200–230ms** |
+| Refresh P50 (moderate) | 3ms | 140ms | 260ms | 110ms | **110ms** |
+| Refresh P95 (stress) | — | 310ms | **29,000ms** | 3,000ms | **430ms** |
+| Stress phase pass rate | 4/4 ✓ | n/a | 4/4 ✓ | 4/4 ✓ | **4/4 ✓** |
+| Total errors | 0 | 509 (burst) | 0 | 0 | **0** |
+
+## TODO
+
+- [ ] Re-run with 5+ replicas to measure whether transaction mode shows a measurable connection-pool benefit at higher concurrency.
+- [ ] Login throughput trend: 93 → 36 → 24 → 19 → 29.5 RPS. Run 8 recovery confirms run 7 drop was outage-attributable. Establish clean post-outage baseline as reference for future runs.
+
+## Agent Report
+
+**Agent:** Master agent
+**Timestamp:** 2026-04-11T01:40:00Z
+**Status:** completed — 8/8 phases passed, 0 errors; PgBouncer transaction mode confirmed compatible.
+
+### Extension
+
+**Agents involved:** master agent (GHA monitoring, artifact extraction, Honeycomb trace analysis, report authoring)
+**Service code issue found:** no
+**New guardrail needed:** no
+**Rules to save in CLAUDE.md:** none

--- a/internal/repository/postgres/postgres.go
+++ b/internal/repository/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+	"net/url"
 
 	"github.com/XSAM/otelsql"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -19,9 +20,28 @@ type DB struct {
 	conn *sql.DB
 }
 
+// withSimpleProtocol appends default_query_exec_mode=simple_protocol to the DSN.
+// Required for PgBouncer transaction mode — prepared statements are not preserved
+// across connections in transaction mode, so pgx must use the simple wire protocol.
+// Safe to apply in session mode too (no functional difference, minor perf overhead).
+func withSimpleProtocol(dsn string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	q := u.Query()
+	q.Set("default_query_exec_mode", "simple_protocol")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
 // New opens a PostgreSQL database at the given DSN and runs migrations.
 // dsn may be a URI (postgres://...) or a key-value DSN (host=... port=...).
 func New(dsn string) (*DB, error) {
+	dsn, err := withSimpleProtocol(dsn)
+	if err != nil {
+		return nil, err
+	}
 	conn, err := otelsql.Open("pgx", dsn,
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{DisableQuery: true}),


### PR DESCRIPTION
## Summary

- `feat(postgres): PgBouncer transaction mode via simple protocol` — adds `withSimpleProtocol()` to inject `default_query_exec_mode=simple_protocol` into the DSN; required for PgBouncer transaction mode. Removes redundant `-p` flag from `railway up`.

## Validation

Run 8 (load test, Railway, 2 replicas): **8/8 phases passed, 0 errors.** Honeycomb trace analysis confirmed no regressions. See `docs/testing_reports/load/run8 railway - 20260411_011909.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)