### PR TITLE
promote develop → main (fix: 503 on refresh token store failure)

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -473,8 +473,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TokenResponse"
+        "400":
+          description: Missing refresh_token field
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "401":
-          description: Invalid or expired refresh token
+          description: Invalid, expired, revoked, or already-consumed refresh token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Token store unavailable (e.g. Redis unreachable)
           content:
             application/json:
               schema:

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -91,8 +92,11 @@ func (ts *TokenService) ValidateAccessToken(tokenStr string) (*Claims, error) {
 // calls both pass Find before either reaches Delete.
 func (ts *TokenService) RefreshAccessToken(ctx context.Context, refreshToken string, users UserLookup) (newAccess, newRefresh string, err error) {
 	userID, err := ts.store.Consume(ctx, refreshToken)
-	if err != nil {
+	if errors.Is(err, model.ErrInvalidToken) {
 		return "", "", ErrInvalidToken
+	}
+	if err != nil {
+		return "", "", err // infrastructure error (e.g. Redis unreachable) — propagate as-is
 	}
 
 	user, err := users.GetUserByID(ctx, userID)

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -277,6 +277,50 @@ func TestRefreshAccessToken_InvalidToken(t *testing.T) {
 	}
 }
 
+func TestRefreshAccessToken_StoreError_NotWrappedAsErrInvalidToken(t *testing.T) {
+	storeErr := errors.New("redis: connection pool: failed to dial")
+	tokens := auth.NewTokenService(
+		[]byte("test-secret-that-is-long-enough-32c"),
+		time.Hour,
+		7*24*time.Hour,
+		&errRefreshStore{err: storeErr},
+	)
+
+	_, _, err := tokens.RefreshAccessToken(context.Background(), "any-token", &stubUserLookup{})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatal("store infrastructure error must not be reported as ErrInvalidToken")
+	}
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("expected original store error to be propagated, got %v", err)
+	}
+}
+
+// errRefreshStore returns a fixed error from every method.
+type errRefreshStore struct{ err error }
+
+func (s *errRefreshStore) Save(_ context.Context, _, _ string, _ time.Time) error {
+	return s.err
+}
+func (s *errRefreshStore) Find(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
+func (s *errRefreshStore) Consume(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
+func (s *errRefreshStore) Delete(_ context.Context, _ string) error { return s.err }
+func (s *errRefreshStore) DeleteAllForUser(_ context.Context, _ string) error {
+	return s.err
+}
+
+type stubUserLookup struct{}
+
+func (s *stubUserLookup) GetUserByID(_ context.Context, _ string) (*model.User, error) {
+	return nil, errors.New("should not be called")
+}
+
 // --- RevokeRefreshToken ---
 
 func TestRevokeRefreshToken_PreventsReuse(t *testing.T) {

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -96,8 +96,12 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 	access, refresh, err := h.tokens.RefreshAccessToken(c.Request.Context(), req.RefreshToken, h.service)
-	if err != nil {
+	if errors.Is(err, auth.ErrInvalidToken) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired refresh token"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "token store unavailable"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -354,6 +355,52 @@ func TestRefresh_ConsumedToken(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 on reuse of consumed token, got %d: %s", w.Code, w.Body.String())
 	}
+}
+
+func TestRefresh_StoreUnavailable_Returns503(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	userRepo := sqlite.NewUserRepo(db)
+	metaRepo := sqlite.NewMetaFieldRepo(db)
+	receiptRepo := sqlite.NewReceiptRepo(db, metaRepo)
+	authService := auth.NewService(userRepo)
+	tokens := auth.NewTokenService(
+		[]byte("test-secret-that-is-long-enough-32c"),
+		time.Hour,
+		7*24*time.Hour,
+		&failingRefreshStore{err: errors.New("redis: connection pool: failed to dial")},
+	)
+	authHandler := handler.NewAuthHandler(authService, tokens)
+	userHandler := handler.NewUserHandler(userRepo)
+	metaHandler := handler.NewMetaHandler(metaRepo)
+	receiptHandler := handler.NewReceiptHandler(receiptRepo)
+	r := handler.NewRouter(authHandler, userHandler, metaHandler, receiptHandler, tokens, nil, nil)
+
+	body := jsonBody(t, map[string]string{"refresh_token": "any-token"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for store unavailable, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// failingRefreshStore returns a fixed infrastructure error from every method.
+type failingRefreshStore struct{ err error }
+
+func (s *failingRefreshStore) Save(_ context.Context, _, _ string, _ time.Time) error {
+	return s.err
+}
+func (s *failingRefreshStore) Find(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
+func (s *failingRefreshStore) Consume(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
+func (s *failingRefreshStore) Delete(_ context.Context, _ string) error { return s.err }
+func (s *failingRefreshStore) DeleteAllForUser(_ context.Context, _ string) error {
+	return s.err
 }
 
 // --- Me tests (additional) ---


### PR DESCRIPTION
## Summary

Promotes `develop` to `main` with one fix:

- **fix: return 503 instead of 401 when the refresh token store is unavailable** (#152)

  Redis DNS timeouts (e.g. `lookup redis-sd3s.railway.internal: i/o timeout`) were incorrectly mapped to 401, causing clients to discard valid refresh tokens during infrastructure outages. Now returns 503 so clients can retry without forcing re-login.

## Test plan

- [x] All tests pass: `go test ./internal/auth/... ./internal/handler/...`
- [x] New tests cover the store-error path at both the service and handler layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)